### PR TITLE
added proxy support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -4,6 +4,12 @@ var request = require('request')
   , log = require('npmlog')
   , url = require('url')
 
+var proxyServer = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
+
+if (proxyServer) {
+  request = request.defaults({ proxy: proxyServer, timeout: 5000 });
+}
+
 module.exports = Client
 
 function Client() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcr",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A node gitlab-ci-runner",
   "main": "./lib/gcr.js",
   "bin": {
@@ -13,7 +13,7 @@
     "nconf": "~0.6.9",
     "nopt": "~2.2.0",
     "npmlog": "~0.0.6",
-    "request": "~2.34.0",
+    "request": "~2.53.0",
     "rimraf": "^2.2.6",
     "slide": "~1.1.5",
     "which": "^1.0.5"


### PR DESCRIPTION
If you are behind a corporate proxy this won't work. So I added proxy
support to the `request` module. This uses the standard `HTTP_PROXY` env
variable that almost everyone is using.

Also `request` needs to be updated also because of this https://github.com/request/request/issues/779