### PR TITLE
Add Secret Variables support

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -151,6 +151,12 @@ Build.prototype.runCommand = function(cmd, dir, cb) {
   , CI_BUILD_ID: this.opts.id
   }
 
+  if (this.opts.variables && this.opts.variables.length) {
+    this.opts.variables.forEach(function(variable) {
+      env[variable.key] = variable.value;
+    });
+  }
+
   util._extend(env, process.env)
 
   var opts = {
@@ -224,6 +230,12 @@ Build.prototype.gitCommand = function(cmd, dir, cb) {
   , CI_BUILD_BEFORE_SHA: this.opts.before_sha
   , CI_BUILD_REF_NAME: this.opts.ref_name
   , CI_BUILD_ID: this.opts.id
+  }
+
+  if (this.opts.variables && this.opts.variables.length) {
+    this.opts.variables.forEach(function(variable) {
+      env[variable.key] = variable.value;
+    });
   }
 
   util._extend(env, process.env)

--- a/lib/client.js
+++ b/lib/client.js
@@ -107,6 +107,7 @@ Client.prototype.getBuild = function(cb) {
       , ref_name: body.before_sha
       , allow_git_fetch: body.allow_git_fetch
       , timeout: body.timeout
+      , variables: body.variables
       }
       return cb && cb(null, o)
     } else if (res.statusCode === 403) {


### PR DESCRIPTION
GitLab CI deprecated project settings in favor of a yaml file. With
this change they introduced Secret Variables to keep sensitive
information such as tokens & passwords away from version control.

Secret Variables allow admins to define environment variables that will
be passed on to the runner.