### PR TITLE
Windows command runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage
 test/home/.config
+test/home/builds
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 test/home/.config
+node_modules/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ gcr - a gitlab ci runner
       -s, --strictSSL             enable/disable strict ssl
       -n, --npm                   run npm install/test if no commands are present
       -k, --keypath <path>        specify path to rsa key
+      -s, --shell <path>          specify path to shell e.g. /bin/bash
+      -sf, --shellFlag <flag>     set the flag to run commands on your shell e.g. -c
 ```
 
 ## Why?

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -38,7 +38,7 @@ var gcr = require('../lib/gcr')
                 , T: ['--timeout']
                 , k: ['--keypath']
                 , s: ['--shell']
-                , sf: ['--shellFlag']
+                , f: ['--shellFlag']
                 , C: ['--sslcert']
                 , K: ['--sslkey']
                 , A: ['--cacert']

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -20,6 +20,8 @@ var gcr = require('../lib/gcr')
                 , strictSSL: Boolean
                 , timeout: Number
                 , keypath: path
+                , shell: path
+                , shellFlag: String
                 }
   , shortHand = { verbose: ['--loglevel', 'verbose']
                 , h: ['--help']
@@ -30,6 +32,8 @@ var gcr = require('../lib/gcr')
                 , s: ['--strictSSL']
                 , T: ['--timeout']
                 , k: ['--keypath']
+                , s: ['--shell']
+                , sf: ['--shellFlag']
                 }
   , parsed = nopt(knownOpts, shortHand)
 

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -16,3 +16,5 @@ gcr - a gitlab ci runner
       -s, --strictSSL             enable/disable strict ssl
       -n, --npm                   run npm install/test if no commands are present
       -k, --keypath <path>        specify path to rsa key
+      -s, --shell <path>          specify path to shell e.g. /bin/bash
+      -sf, --shellFlag <flag>     set the flag to run commands on your shell e.g. -c

--- a/lib/build.js
+++ b/lib/build.js
@@ -173,7 +173,11 @@ Build.prototype.runCommand = function(cmd, dir, cb) {
   log.verbose('[builder]', 'cmd', cmd)
   this.append(util.format('\n%s\n', cmd))
 
-  var child = spawn('/bin/bash', ['-c', fixedCmd.join(' ')], opts)
+  if(process.platform === 'win32'){
+    var child = spawn('cmd.exe', ['/C', fixedCmd.join(' ')], opts)
+  }else{
+    var child = spawn('/bin/bash', ['-c', fixedCmd.join(' ')], opts)
+  }
   var timedout = false
   var timer = setTimeout(function() {
     timedout = true

--- a/lib/build.js
+++ b/lib/build.js
@@ -173,11 +173,7 @@ Build.prototype.runCommand = function(cmd, dir, cb) {
   log.verbose('[builder]', 'cmd', cmd)
   this.append(util.format('\n%s\n', cmd))
 
-  if(process.platform === 'win32'){
-    var child = spawn('cmd.exe', ['/C', fixedCmd.join(' ')], opts)
-  }else{
-    var child = spawn('/bin/bash', ['-c', fixedCmd.join(' ')], opts)
-  }
+  var child = spawn(gcr.config.get('shell'), [gcr.config.get('shellFlag'), fixedCmd.join(' ')], opts)
   var timedout = false
   var timer = setTimeout(function() {
     timedout = true

--- a/lib/config.default.js
+++ b/lib/config.default.js
@@ -19,5 +19,8 @@ module.exports = function(parsed) {
   o.strictSSL = parsed.hasOwnProperty('strictSSL')
               ? parsed.strictSSL
               : true
+
+  o.shell = parsed.shell ? parsed.shell : isWin ? 'C:\\Windows\\System32\\cmd.exe' : '/bin/bash'
+  o.shellFlag = parsed.shellFlag ? parsed.shellFlag : isWin ? '/C' : '-c'
   return o
 }

--- a/lib/gcr.js
+++ b/lib/gcr.js
@@ -15,7 +15,8 @@ log.heading = 'gcr'
 
 module.exports = gcr
 
-gcr.root = path.dirname(confFile)
+gcr.confFile = confFile
+gcr.root = path.dirname(gcr.confFile)
 gcr.loaded = false
 gcr.version = require('../package').version
 
@@ -30,7 +31,7 @@ gcr.load = function(opts, cb) {
       err.heading = '[mkdirp]'
       return cb(err)
     }
-    nconf.file({ file: confFile })
+    nconf.file({ file: gcr.confFile })
     nconf.defaults(require('./config.default')(opts))
     if (opts.url) {
       nconf.set('url', opts.url)

--- a/lib/gcr.js
+++ b/lib/gcr.js
@@ -57,6 +57,12 @@ gcr.load = function(opts, cb) {
     if (opts.keypath) {
       nconf.set('keypath', opts.keypath)
     }
+    if (opts.shell) {
+      nconf.set('shell', opts.shell)
+    }
+    if (opts.shellFlag) {
+      nconf.set('shellFlag', opts.shellFlag)
+    }
     gcr.config = nconf
     chain([
         validateGit

--- a/test/gcr.js
+++ b/test/gcr.js
@@ -74,6 +74,11 @@ describe('gcr', function() {
     gcr.should.have.property('config')
   })
 
+  it('should set the shell options', function(){
+    gcr.config.get('shell').should.exist
+    gcr.config.get('shellFlag').should.exist
+  })
+
   describe('build', function() {
     var Build = require('../lib/build')
     var build

--- a/test/gcr.js
+++ b/test/gcr.js
@@ -18,6 +18,9 @@ describe('gcr', function() {
       port = server.address().port
       done()
     })
+
+    gcr.root = path.join(HOME, '.config')
+    gcr.confFile = path.join(HOME, '.config', 'gcr.json')
   })
 
   it('should be an EventEmitter', function() {
@@ -27,6 +30,11 @@ describe('gcr', function() {
   it('should have property root', function() {
     should.exist(gcr.root)
     gcr.root.should.equal(path.join(HOME, '.config'))
+  })
+
+  it('should have property confFile', function(){
+    should.exist(gcr.confFile)
+    gcr.confFile.should.equal(path.join(HOME, '.config', 'gcr.json'))
   })
 
   it('should have property loaded', function() {
@@ -46,7 +54,7 @@ describe('gcr', function() {
     gcr.load({
       url: 'http://127.0.0.1:' + port + '/ci'
     , token: 'biscuits'
-    , buildDir: '/tmp/gcr-builds'
+    , buildDir: __dirname + '/home/builds'
     , npm: true
     , strictSSL: false
     , timeout: 5000
@@ -89,7 +97,7 @@ describe('gcr', function() {
       build.should.have.property('opts')
       build.should.have.property('output')
       build.should.have.property('projectDir')
-      build.projectDir.should.equal('/tmp/gcr-builds/project-1')
+      build.projectDir.should.equal(__dirname + '/home/builds/project-1'.replace(/\//g, path.sep))
       build.should.have.property('state', 'waiting')
     })
 

--- a/test/gcr.js
+++ b/test/gcr.js
@@ -64,8 +64,8 @@ test('load', (t) => {
 test('shell selection', (t) => {
   t.plan(2)
   t.match(gcr.config.get('shell')
-    , /cmd\.exe$|\/sh$/
-    , 'Shell is either cmd.exe or /bin/sh'
+    , /cmd\.exe$|\/bash$/
+    , 'Shell is either cmd.exe or /bin/bash'
   )
 
   t.match(gcr.config.get('shellFlag')


### PR DESCRIPTION
Fixes #19 by using `cmd.exe /C` instead of `/bin/bash -c` when the platform is win32

Also ignore node_modules/ (my first git add went nuts with the whole node_modules folder)
