### PR TITLE
explicitely catch SIGTERM for graceful docker exit, replace bash by sh

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -87,6 +87,8 @@ var tokenQuestion = {
   }
 }
 
+process.on('SIGTERM', process.exit)
+
 gcr.load(parsed, function(err) {
   if (err) {
     var t = err.heading || ''

--- a/lib/build.js
+++ b/lib/build.js
@@ -173,7 +173,7 @@ Build.prototype.runCommand = function(cmd, dir, cb) {
   log.verbose('[builder]', 'cmd', cmd)
   this.append(`\n${cmd}\n`)
 
-  const child = spawn('/bin/bash', ['-c', fixedCmd.join(' ')], opts)
+  const child = spawn('/bin/sh', ['-c', fixedCmd.join(' ')], opts)
   var timedout = false
   var timer = setTimeout(() => {
     timedout = true


### PR DESCRIPTION
Handling SIGTERM is required to run gcr as the main docker process, and allow the container to terminate properly when stopped. See https://github.com/mvertes/docker-gitlab-runner-node for such a container definition.

Replacing /bin/bash by /bin/sh improves portability as it is POSIX compliant. It avoids explicit dependency on bash on Linux light distributions or *BSD.