### PR TITLE
Handle SIGTERM explicitely and exit.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -87,6 +87,8 @@ var tokenQuestion = {
   }
 }
 
+process.on('SIGTERM', process.exit)
+
 gcr.load(parsed, function(err) {
   if (err) {
     var t = err.heading || ''


### PR DESCRIPTION
Handling SIGTERM is required to run gcr as the main docker process,
and allow the container to terminate properly when stopped. See
https://github.com/mvertes/docker-gitlab-runner-node for such a
container definition.