### PR TITLE
Replace /bin/bash by /bin/sh

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -173,7 +173,7 @@ Build.prototype.runCommand = function(cmd, dir, cb) {
   log.verbose('[builder]', 'cmd', cmd)
   this.append(`\n${cmd}\n`)
 
-  const child = spawn('/bin/bash', ['-c', fixedCmd.join(' ')], opts)
+  const child = spawn('/bin/sh', ['-c', fixedCmd.join(' ')], opts)
   var timedout = false
   var timer = setTimeout(() => {
     timedout = true


### PR DESCRIPTION
Replacing /bin/bash by /bin/sh improves portability as it is POSIX
compliant. It avoids explicit dependency on bash on Linux light
distributions or *BSD.