### PR TITLE
Adding in ability for GCR to connect to a gitlab that requires 2-way SSL with client certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - changelog
+- Ability to connect to two-way SSL enabled GitLab
 
 ### Changed
 - Minimum Node.js version updated to 4.x

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ gcr - a gitlab ci runner
       -s, --strictSSL             enable/disable strict ssl
       -n, --npm                   run npm install/test if no commands are present
       -k, --keypath <path>        specify path to rsa key
+      -C, --sslcert <path>        enable/disable strict ssl
+      -K, --sslkey <path>         run npm install/test if no commands are present
+      -A, --cacert <path>         specify path to rsa key
 ```
 
 ## Execution Notes

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -22,6 +22,9 @@ var gcr = require('../lib/gcr')
                 , strictSSL: Boolean
                 , timeout: Number
                 , keypath: path
+                , sslcert: path
+                , sslkey: path
+                , cacert: path
                 }
   , shortHand = { verbose: ['--loglevel', 'verbose']
                 , h: ['--help']
@@ -32,6 +35,9 @@ var gcr = require('../lib/gcr')
                 , s: ['--strictSSL']
                 , T: ['--timeout']
                 , k: ['--keypath']
+                , C: ['--sslcert']
+                , K: ['--sslkey']
+                , A: ['--cacert']
                 }
   , parsed = nopt(knownOpts, shortHand)
 

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -16,3 +16,6 @@ gcr - a gitlab ci runner
       -s, --strictSSL             enable/disable strict ssl
       -n, --npm                   run npm install/test if no commands are present
       -k, --keypath <path>        specify path to rsa key
+      -C, --sslcert <path>        enable/disable strict ssl
+      -K, --sslkey <path>         run npm install/test if no commands are present
+      -A, --cacert <path>         specify path to rsa key

--- a/lib/build.js
+++ b/lib/build.js
@@ -78,7 +78,23 @@ Build.prototype.run = function() {
 }
 
 Build.prototype.clone = function(cb) {
-  const cmd = ['clone', this.opts.repo_url, 'project-' + this.opts.project_id]
+  // If necessary, add required options for ssl
+  var gitAuthOpts = []
+  if (gcr.config.get('sslkey'))
+    gitAuthOpts = gitAuthOpts.concat(['--config'
+    , 'http.sslKey=' + gcr.config.get('sslkey')])
+  if (gcr.config.get('sslcert'))
+    gitAuthOpts = gitAuthOpts.concat(['--config'
+    , 'http.sslCert=' + gcr.config.get('sslcert')])
+  if (gcr.config.get('cacert'))
+    gitAuthOpts = gitAuthOpts.concat(['--config'
+    , 'http.sslCaInfo=' + gcr.config.get('cacert')])
+  if (gcr.config.get('sslverify'))
+    gitAuthOpts = gitAuthOpts.concat(['--config'
+    , 'http.sslverify=' + gcr.config.get('sslverify')])
+
+  const cmd = ['clone'].concat(gitAuthOpts,
+    [this.opts.repo_url, 'project-' + this.opts.project_id])
   const dir = this.projectDir
   this.gitCommand(cmd, this.buildDir, (err) => {
     if (err) return cb && cb(err)

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,6 +5,9 @@ const request = require('request')
     , util = require('util')
     , log = require('npmlog')
     , urlJoin = require('url-join')
+    , fs = require('fs')
+    , path = require('path')
+    , splitca = require('split-ca')
 
 const proxyServer = process.env.HTTPS_PROXY
   || process.env.https_proxy
@@ -28,7 +31,7 @@ Client.prototype.apiUrl = function() {
 
 Client.prototype.updateBuild = function(id, state, trace, cb) {
   log.info('[client]', 'submitting build %d to coordinator...', id)
-  const opts = {
+  var opts = {
     body: {
       state: state
     , trace: trace
@@ -37,6 +40,15 @@ Client.prototype.updateBuild = function(id, state, trace, cb) {
   , json: true
   , strictSSL: gcr.config.get('strictSSL')
   }
+  if (gcr.config.get('cacert'))
+    opts.ca = splitca(
+      path.resolve(__dirname, gcr.config.get('cacert')))
+  if (gcr.config.get('sslkey'))
+    opts.key = fs.readFileSync(
+      path.resolve(__dirname, gcr.config.get('sslkey')))
+  if (gcr.config.get('sslcert'))
+    opts.cert = fs.readFileSync(
+      path.resolve(__dirname, gcr.config.get('sslcert')))
 
   log.verbose('[client]', 'update build', id, state)
   opts.uri = urlJoin(
@@ -58,7 +70,7 @@ Client.prototype.updateBuild = function(id, state, trace, cb) {
 }
 
 Client.prototype.registerRunner = function(pubkey, token, cb) {
-  const opts = {
+  var opts = {
     body: {
       public_key: pubkey
     , token: token
@@ -66,6 +78,14 @@ Client.prototype.registerRunner = function(pubkey, token, cb) {
   , json: true
   , strictSSL: gcr.config.get('strictSSL')
   }
+  if (gcr.config.get('cacert'))
+    opts.ca = splitca(path.resolve(__dirname, gcr.config.get('cacert')))
+  if (gcr.config.get('sslkey'))
+    opts.key = fs.readFileSync(
+      path.resolve(__dirname, gcr.config.get('sslkey')))
+  if (gcr.config.get('sslcert'))
+    opts.cert = fs.readFileSync(
+      path.resolve(__dirname, gcr.config.get('sslcert')))
 
   opts.uri = urlJoin(this.apiUrl(), '/api/v1/runners/register.json')
   log.http('POST', opts.uri)
@@ -85,13 +105,22 @@ Client.prototype.registerRunner = function(pubkey, token, cb) {
 Client.prototype.getBuild = function(cb) {
   log.info('[client]', 'checking for builds...')
 
-  const opts = {
+  var opts = {
     body: {
       token: gcr.config.get('token')
     }
   , json: true
   , strictSSL: gcr.config.get('strictSSL')
   }
+  if (gcr.config.get('cacert'))
+    opts.ca = splitca(
+      path.resolve(__dirname, gcr.config.get('cacert')))
+  if (gcr.config.get('sslkey'))
+    opts.key = fs.readFileSync(
+      path.resolve(__dirname, gcr.config.get('sslkey')))
+  if (gcr.config.get('sslcert'))
+    opts.cert = fs.readFileSync(
+      path.resolve(__dirname, gcr.config.get('sslcert')))
 
   opts.uri = urlJoin(this.apiUrl(), '/api/v1/builds/register.json')
   request.post(opts, (err, res, body) => {

--- a/lib/config.default.js
+++ b/lib/config.default.js
@@ -12,6 +12,9 @@ module.exports = function(parsed) {
   if (parsed.buildDir) o.buildDir = parsed.buildDir
   if (parsed.npm) o.npm = parsed.npm
   if (parsed.timeout) o.timeout = parsed.timeout
+  if (parsed.sslcert) o.sslcert = parsed.sslcert
+  if (parsed.sslkey) o.sslkey = parsed.sslkey
+  if (parsed.cacert) o.cacert = parsed.cacert
   o.keypath = parsed.keypath
     ? parsed.key
     : isWin

--- a/lib/gcr.js
+++ b/lib/gcr.js
@@ -57,6 +57,15 @@ gcr.load = function(opts, cb) {
     if (opts.keypath) {
       nconf.set('keypath', opts.keypath)
     }
+    if (opts.sslcert) {
+      nconf.set('sslcert', opts.sslcert)
+    }
+    if (opts.sslkey) {
+      nconf.set('sslkey', opts.sslkey)
+    }
+    if (opts.cacert) {
+      nconf.set('cacert', opts.cacert)
+    }
     gcr.config = nconf
     chain([
         validateGit

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "rimraf": "~2.2.6",
     "slide": "~1.1.5",
     "url-join": "0.0.1",
-    "which": "~1.0.5"
+    "which": "~1.0.5",
+    "split-ca": "~1.0.1"
   },
   "devDependencies": {
     "lintit": "~1.0.1",


### PR DESCRIPTION
Hey there,

I added a feature to support gitlab servers that require 2-way SSL and client certificates.  While I realize this is not a common situation, it was a big enough problem that it made it impossible for us to use GitLab CI in any capacity.  All the features are optional and will not affect users who do not require Client Certificates.  If this is something you would be interested in merging, great!  If not, I would be interested in publishing a forked version to NPM (gcr-https?) with your permission.
