### PR TITLE
Swapping val and key for queue callback

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -61,7 +61,7 @@ Runner.prototype.getBuild = function() {
 
 Runner.prototype.checkQueue = function() {
   var self = this
-  this.queue.forEach(function(key, val) {
+  this.queue.forEach(function(val, key) {
     if (self.projectIsRunning(+val.project_id))
       return
     self.runBuild(val)


### PR DESCRIPTION
If builds get queued, there will be an explosion.  Looks like the forEach callback was written as `(key, value)` instead of `(value, key)`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach

Sample `.gitlab-ci.yml` to test for yourself.
```
job1:
  script:
  - date
  - sleep 15

job2:
  script:
  - echo 'Hello World!'
  - sleep 15

job3:
  script:
  - echo "Foo!"
  - sleep 15
```